### PR TITLE
BOAD-69: Review spacing in activity preview

### DIFF
--- a/src/activity/preview/ActivityPreview.css
+++ b/src/activity/preview/ActivityPreview.css
@@ -270,13 +270,13 @@
   font-size: 0.85em;
   color: #767676;
   font-weight: bold;
-  padding-top: 10px;
-  padding-bottom: 5px;
+  padding-top: 1px;
+  padding-bottom: 1px;
 }
 
 .box_field_value {
   font-weight: bold;
-  padding-bottom: 10px;
+  padding-bottom: 1px;
 }
 
 .box_field_value_tight {


### PR DESCRIPTION
Review spacing in activity preview. In some places there is an extra space that can be minimized.

After changing padding

![image](https://user-images.githubusercontent.com/29124635/224754878-2b69265e-ae52-479b-9c0d-9b378a63ac99.png)